### PR TITLE
fix Highlight formatter when no description available

### DIFF
--- a/frontend/trends/webapp/model/formatter.js
+++ b/frontend/trends/webapp/model/formatter.js
@@ -43,6 +43,9 @@ sap.ui.define([], function () {
         },
 
         formatHighlight: function (string, highlight) {
+            if(!string){
+                return ""
+            }
             if (!highlight) {
                 return string;
             }


### PR DESCRIPTION
Reproduce the problem:
Go to the 'all' page
Use the search here and type 'ui5'.
Expand results and try to show results 75-100
Since the artifact has no description, an error is thrown in the 'formatHighlight' method in the formatter that was not caught.

Suggested solution:
Check if 'string' value is 'null'.