### PR TITLE
add filter by type in search

### DIFF
--- a/frontend/trends/webapp/controller/MainView.controller.js
+++ b/frontend/trends/webapp/controller/MainView.controller.js
@@ -52,7 +52,11 @@ sap.ui.define(
             },
 
             liveSearch: function (oEvent) {
-                const value = oEvent.getParameter("newValue");
+                const model = this.getView().getModel("settings");
+                let value = model.getProperty("/search");
+                if(!value){value = ""}
+                let valueType  = model.getProperty("/filterSearch");
+                if(valueType === undefined ||  valueType === 'all'){valueType = ""}
                 const list = this.getView().byId("all-list");
                 const listBinding = list.getBinding("items");
                 const nameFilter = new sap.ui.model.Filter({
@@ -68,12 +72,16 @@ sap.ui.define(
                 const typeFilter = new sap.ui.model.Filter({
                     path: "type",
                     operator: sap.ui.model.FilterOperator.Contains,
-                    value1: value,
+                    value1: valueType,
                 });
+                const searchFilter = new sap.ui.model.Filter({
+                    filters: [nameFilter, descFilter],
+                    and: false,
+                })
                 listBinding.filter(
                     new sap.ui.model.Filter({
-                        filters: [nameFilter, descFilter, typeFilter],
-                        and: false,
+                        filters: [searchFilter, typeFilter],
+                        and: true,
                     })
                 );
             },

--- a/frontend/trends/webapp/view/AllPage.view.xml
+++ b/frontend/trends/webapp/view/AllPage.view.xml
@@ -8,7 +8,38 @@
         <OverflowToolbar id="all-list-bar">
           <Title id="all-bar-info" text="{i18n>all}" level="H4" />
           <ToolbarSpacer id="all-bar-spacer" />
-          <SearchField id="all-bar-search" width="60%" liveChange=".liveSearch" value="{settings>/search}" />
+          <SearchField id="all-bar-search" width="60%" liveChange=".liveSearch" value="{settings>/search}">
+          <layoutData>
+				      <OverflowToolbarLayoutData
+                shrinkable="true"
+                minWidth = "40%"/>
+			      </layoutData>
+          </SearchField>
+          <SegmentedButton id="trend-list-bar-segmented" selectionChange=".liveSearch" selectedKey="{settings>/filterSearch}"
+            class="sapUiSizeCompact sapUiTinyMarginTopBottom">
+            <layoutData>
+				      <OverflowToolbarLayoutData group="1"/>
+			      </layoutData>
+            <items>
+              <SegmentedButtonItem id="trend-list-bar-segment-1" text="{i18n>all}" key="all" />
+              <SegmentedButtonItem id="trend-list-bar-segment-2" text="{i18n>npm-packages}" key="npm-package" visible="{
+                  path: 'trendData>/overall',
+                  formatter: '.formatter.containsNpmPackages'
+                }" />
+              <SegmentedButtonItem id="trend-list-bar-segment-3" text="{i18n>code-repositories}" visible="{
+                  path: 'trendData>/overall',
+                  formatter: '.formatter.containsCodeRepositories'
+                }" key="code-repository" />
+              <SegmentedButtonItem id="trend-list-bar-segment-4" text="{i18n>pypi-packages}" key="pypi-package" visible="{
+                path: 'trendData>/overall',
+                formatter: '.formatter.containsPypiPackages'
+              }" />
+              <SegmentedButtonItem id="trend-list-bar-segment-5" text="{i18n>docker-images}" key="docker-image" visible="{
+                path: 'trendData>/overall',
+                formatter: '.formatter.containsDockerImages'
+              }" />
+            </items>
+          </SegmentedButton>
         </OverflowToolbar>
       </headerToolbar>
       <CustomListItem id="all-listitem">

--- a/frontend/trends/webapp/view/AllPage.view.xml
+++ b/frontend/trends/webapp/view/AllPage.view.xml
@@ -10,16 +10,13 @@
           <ToolbarSpacer id="all-bar-spacer" />
           <SearchField id="all-bar-search" width="60%" liveChange=".liveSearch" value="{settings>/search}">
           <layoutData>
-				      <OverflowToolbarLayoutData
+				  <OverflowToolbarLayoutData
                 shrinkable="true"
                 minWidth = "40%"/>
 			      </layoutData>
           </SearchField>
           <SegmentedButton id="trend-list-bar-segmented" selectionChange=".liveSearch" selectedKey="{settings>/filterSearch}"
             class="sapUiSizeCompact sapUiTinyMarginTopBottom">
-            <layoutData>
-				      <OverflowToolbarLayoutData group="1"/>
-			      </layoutData>
             <items>
               <SegmentedButtonItem id="trend-list-bar-segment-1" text="{i18n>all}" key="all" />
               <SegmentedButtonItem id="trend-list-bar-segment-2" text="{i18n>npm-packages}" key="npm-package" visible="{


### PR DESCRIPTION
It's nice that you can filter by type.
Unfortunately, this is quite difficult in the search.
You would have to enter the exact type (e.g. "npm-package") so that only the type is filtered.
I have now added the SegmentButtons to the all page.
Due to the "shrinkable" property, the search field is now also displayed on mobile devices and not hidden in the context menu.

What do you think? @IObert 