### PR TITLE
remove growing attributes from list

### DIFF
--- a/frontend/trends/webapp/view/NewArtifactsPage.view.xml
+++ b/frontend/trends/webapp/view/NewArtifactsPage.view.xml
@@ -3,7 +3,7 @@
 
   <ScrollContainer id="trends-page" horizontal="false" vertical="true" height="100%">
     <!-- <Text id="trend-intro" text="{i18n>appDescription}" class="sapUiSmallMargin" /> -->
-    <List id="trend-list" growing="true" growingThreshold="25" 
+    <List id="trend-list"
       items="{path: 'trendData>/newlyAdded'}" noDataText="{i18n>noRankingType}">
       <headerToolbar>
         <OverflowToolbar id="trend-list-bar">

--- a/frontend/trends/webapp/view/TrendsPage.view.xml
+++ b/frontend/trends/webapp/view/TrendsPage.view.xml
@@ -3,7 +3,7 @@
 
   <ScrollContainer id="trends-page" horizontal="false" vertical="true" height="100%">
     <!-- <Text id="trend-intro" text="{i18n>appDescription}" class="sapUiSmallMargin" /> -->
-    <List id="trend-list" growing="true" growingThreshold="25" 
+    <List id="trend-list"
       items="{path: 'trendData>/overall'}" noDataText="{i18n>noRankingType}">
       <headerToolbar>
         <OverflowToolbar id="trend-list-bar">

--- a/frontend/trends/webapp/view/UpdatedArtifactsPage.view.xml
+++ b/frontend/trends/webapp/view/UpdatedArtifactsPage.view.xml
@@ -3,7 +3,7 @@
 
   <ScrollContainer id="trends-page" horizontal="false" vertical="true" height="100%">
     <!-- <Text id="trend-intro" text="{i18n>appDescription}" class="sapUiSmallMargin" /> -->
-    <List id="trend-list" growing="true" growingThreshold="25"
+    <List id="trend-list"
       items="{path: 'trendData>/recentlyUpdated'}" noDataText="{i18n>noRankingType}">
       <headerToolbar>
         <OverflowToolbar id="trend-list-bar">


### PR DESCRIPTION
**Error**:
You call up the page https://sap-samples.github.io/artifact-of-the-month/ and filter for "Code Repositories". However, no repositories are displayed although there are two available in the top 99.

**Cause**:
Since the 'growing' attribute is used in the list control, only the first 25 entries are loaded.
Only these are filtered for ''Repos''.
In this case, the repo on position 37 and 81 is not displayed.

**Suggested solution:**
Remove the 'growing' parameter in the views 'new', 'trends' and 'updated'.
Since there are only 99 entries in these views anyway, the performance decrease is minimal.
The view 'all' is not affected by this, because there is a different filter process.