### PR TITLE
Specify a fixed UI5 version

### DIFF
--- a/frontend/trends/webapp/index.html
+++ b/frontend/trends/webapp/index.html
@@ -21,7 +21,7 @@
         })();
     </script>
 
-    <script id="sap-ui-bootstrap" src="https://openui5.hana.ondemand.com/resources/sap-ui-core.js"
+    <script id="sap-ui-bootstrap" src="https://openui5.hana.ondemand.com/1.93.0/resources/sap-ui-core.js"
         data-sap-ui-resourceroots='{
     "aow.artifact": "./"
 }' data-sap-ui-oninit="module:sap/ui/core/ComponentSupport" data-sap-ui-compatVersion="edge" data-sap-ui-async="true"


### PR DESCRIPTION
Hi Marius,
You define the UI5 version as 1.93.0 and the new version is always used automatically.
Of course, this also introduces bugs like the InfoLabel Colors are gone.
![image](https://user-images.githubusercontent.com/13335743/137290773-8b93ceb5-6eda-4d59-9b6a-7d80500bab0b.png)

So the question is, do you want to specify a fixed UI5 version at all, and if so, is this the right place?