### PR TITLE
feat: collapse sidebar after navigation if on mobile

### DIFF
--- a/frontend/trends/webapp/controller/BaseController.js
+++ b/frontend/trends/webapp/controller/BaseController.js
@@ -67,6 +67,16 @@ sap.ui.define(
                     this.getRouter().navTo("appHome", {}, true /*no history*/);
                 }
             },
+
+            /**
+             * Convenience method for return if user is on mobile
+             * @public
+             * @returns {boolean} returns true if the user is on mobile
+             */
+            isMobile: function () {
+                return !this.getModel("device").getProperty("/orientation/landscape") ||
+                this.getModel("device").getProperty("/browser/mobile")
+            }
         });
     }
 );

--- a/frontend/trends/webapp/controller/MainView.controller.js
+++ b/frontend/trends/webapp/controller/MainView.controller.js
@@ -49,6 +49,10 @@ sap.ui.define(
                 this.navTo(item);
                 model.setProperty("/currentHash", item);
                 model.setProperty("/filter", "all");
+                // collapse sidebar after navigation if on mobile
+                if (this.isMobile()) {
+                    model.setProperty("/sidebarExpanded", false);
+                }
             },
 
             displayItem: function (event) {


### PR DESCRIPTION
When navigating mobile the sidebar always remains and you have to collapse it manually so that you can read the text there.
Hereby this will be collapsed automatically with the same parameters as already worked in the view.
## before
![before](https://user-images.githubusercontent.com/13335743/142665139-04f6a6c0-2314-4669-9592-3cc4a8708046.gif)
## after
![after](https://user-images.githubusercontent.com/13335743/142665165-27dd444e-2f93-4fe5-8c4a-e7c03155cb6c.gif)


